### PR TITLE
Fix some textures

### DIFF
--- a/OTRExporter/DisplayListExporter.cpp
+++ b/OTRExporter/DisplayListExporter.cpp
@@ -722,9 +722,6 @@ void OTRExporter_DisplayList::Save(ZResource* res, const fs::path& outPath, Bina
 			}
 			else
 			{
-				std::string texName = "";
-				bool foundDecl = Globals::Instance->GetSegmentedPtrName(seg, dList->parent, "", texName, res->parent->workerID);
-
 				int32_t __ = (data & 0x00FF000000000000) >> 48;
 				int32_t www = (data & 0x00000FFF00000000) >> 32;
 
@@ -740,18 +737,35 @@ void OTRExporter_DisplayList::Save(ZResource* res, const fs::path& outPath, Bina
 				writer->Write(word0);
 				writer->Write(word1);
 
+				bool foundDecl = false;
+				std::string resourcePath = "";
+
+				// First check current file
+				if (res->parent->segment == GETSEGNUM(seg)) {
+					uint32_t segmentOffset = GETSEGOFFSET(seg);
+					Declaration* resourceDecl = dList->parent->GetDeclaration(segmentOffset);
+
+					if (resourceDecl != nullptr)
+					{
+						foundDecl = true;
+						resourcePath = OTRExporter_DisplayList::GetPathToRes(res, resourceDecl->declName);
+					}
+				}
+
+				// Then check in global resources
+				if (!foundDecl) {
+					foundDecl = Globals::Instance->GetSegmentedPtrName(seg, dList->parent, "", resourcePath, res->parent->workerID);
+
+					if (foundDecl) {
+						ZFile* assocFile = Globals::Instance->GetSegment(GETSEGNUM(seg), res->parent->workerID);
+						std::string assocFileName = assocFile->GetName();
+						resourcePath = GetPathToRes(assocFile->resources[0], resourcePath);
+					}
+				}
+
 				if (foundDecl)
 				{
-					ZFile* assocFile = Globals::Instance->GetSegment(GETSEGNUM(seg), res->parent->workerID);
-					std::string assocFileName = assocFile->GetName();
-					std::string fName = "";
-
-					if (GETSEGNUM(seg) == SEGMENT_SCENE || GETSEGNUM(seg) == SEGMENT_ROOM)
-						fName = GetPathToRes(res, texName.c_str());
-					else
-						fName = GetPathToRes(assocFile->resources[0], texName.c_str());
-
-					uint64_t hash = CRC64(fName.c_str());
+					uint64_t hash = CRC64(resourcePath.c_str());
 
 					word0 = hash >> 32;
 					word1 = hash & 0xFFFFFFFF;


### PR DESCRIPTION
This fixes another issue with a DL referencing a resource outside of it's own file, in this case textures.

Textures were already sort of set up to support this, but in a way that made wrong assumptions and ended up with invalid resource paths, like `misc/link_animetion/gGiPotionContainerGreenPatternTex`

This fixes https://github.com/HarbourMasters/2ship2harkinian/issues/59