### PR TITLE
Handle all segment lookups for VTX commands

### DIFF
--- a/OTRExporter/DisplayListExporter.cpp
+++ b/OTRExporter/DisplayListExporter.cpp
@@ -781,17 +781,15 @@ void OTRExporter_DisplayList::Save(ZResource* res, const fs::path& outPath, Bina
 		break;
 		case G_VTX:
 		{
-			if (GETSEGNUM(data) == 0xC || GETSEGNUM(data) == 0x8)
+			if (!Globals::Instance->HasSegment(GETSEGNUM(data), res->parent->workerID))
 			{
-				// hack for dynamic verticies used in en_ganon_mant and en_jsjutan
-				// TODO is there a better way?
 				int32_t aa = (data & 0x000000FF00000000ULL) >> 32;
 				int32_t nn = (data & 0x000FF00000000000ULL) >> 44;
 
-				Gfx value = {gsSPVertex(data & 0xFFFFFFFF, nn, ((aa >> 1) - nn))};
+				Gfx value = {gsSPVertex((data & 0xFFFFFFFF) + 1, nn, ((aa >> 1) - nn))};
 
 				word0 = value.words.w0;
-				word1 = value.words.w1 | 1;
+				word1 = value.words.w1;
 			}
 			else
 			{


### PR DESCRIPTION
Lookups for segmented VTX commands was only considering `0x08` and `0x0C` from OOT, but MM also uses `0x09` and `0x0B` for segmented VTX values that was being lost leading to broken DLists.

I'm not sure the history for the hack, but switching `G_VTX` to leverage `HasSegment()` like all the other commands was sufficient to fix MM and retain OOT generating correctly. I removed the comments since they are no longer needed, and then I moved the `+ 1` to the `gsSPVertex` macro to clarify where it is being used.