### PR TITLE
Handle segment addresses for other files in limb dlists

### DIFF
--- a/OTRExporter/SkeletonLimbExporter.cpp
+++ b/OTRExporter/SkeletonLimbExporter.cpp
@@ -134,7 +134,9 @@ void OTRExporter_SkeletonLimb::Save(ZResource* res, const fs::path& outPath, Bin
 			if (name.at(0) == '&')
 				name.erase(0, 1);
 
-			writer->Write(OTRExporter_DisplayList::GetPathToRes(limb, name));
+			ZFile* assocFile = Globals::Instance->GetSegment(GETSEGNUM(limb->dListPtr), res->parent->workerID);
+
+			writer->Write(OTRExporter_DisplayList::GetPathToRes(assocFile->resources[0], name));
 		}
 		else
 		{
@@ -155,7 +157,9 @@ void OTRExporter_SkeletonLimb::Save(ZResource* res, const fs::path& outPath, Bin
 			if (name.at(0) == '&')
 				name.erase(0, 1);
 
-			writer->Write(OTRExporter_DisplayList::GetPathToRes(limb, name));
+			ZFile* assocFile = Globals::Instance->GetSegment(GETSEGNUM(limb->dList2Ptr), res->parent->workerID);
+
+			writer->Write(OTRExporter_DisplayList::GetPathToRes(assocFile->resources[0], name));
 		}
 		else
 		{


### PR DESCRIPTION
Limbs that had DLs from external files were not building the correct otr path string. This aligns with how we handle DLs that reference DLs from external files. Fixes zora/deku/goron mask cutscenes.

Before: `objects/object_dmask/gZoraMaskDL`
After: `objects/gameplay_keep/gZoraMaskDL`