### PR TITLE
Fix: Handle null lists in animated texture color params

### DIFF
--- a/OTRExporter/TextureAnimationExporter.cpp
+++ b/OTRExporter/TextureAnimationExporter.cpp
@@ -43,25 +43,40 @@ void OTRExporter_TextureAnimation::Save(ZResource* res, const fs::path& outPath,
 				writer->Write(colorParams->animLength);
 				writer->Write(colorParams->colorListCount);
 
-				writer->Write((uint32_t)colorParams->frameDataList.size());
-				for (const auto f : colorParams->frameDataList) {
-					writer->Write(f);
+				if (colorParams->frameDataListAddress != 0) { // NULL
+					writer->Write((uint16_t)colorParams->frameDataList.size());
+					for (const auto f : colorParams->frameDataList) {
+						writer->Write(f);
+					}
+				} else {
+					writer->Write((uint16_t)0);
 				}
-				writer->Write((uint32_t)colorParams->primColorList.size());
-				for (const auto prim : colorParams->primColorList) {
-					writer->Write(prim.r);
-					writer->Write(prim.g);
-					writer->Write(prim.b);
-					writer->Write(prim.a);
-					writer->Write(prim.lodFrac);
+
+				if (colorParams->primColorListAddress != 0) { // NULL
+					writer->Write((uint16_t)colorParams->primColorList.size());
+					for (const auto prim : colorParams->primColorList) {
+						writer->Write(prim.r);
+						writer->Write(prim.g);
+						writer->Write(prim.b);
+						writer->Write(prim.a);
+						writer->Write(prim.lodFrac);
+					}
+				} else {
+					writer->Write((uint16_t)0);
 				}
-				writer->Write((uint16_t)colorParams->envColorList.size());
-				for (const auto env : colorParams->envColorList) {
-					writer->Write(env.r);
-					writer->Write(env.g);
-					writer->Write(env.b);
-					writer->Write(env.a);
+
+				if (colorParams->envColorListAddress != 0) { // NULL
+					writer->Write((uint16_t)colorParams->envColorList.size());
+					for (const auto env : colorParams->envColorList) {
+						writer->Write(env.r);
+						writer->Write(env.g);
+						writer->Write(env.b);
+						writer->Write(env.a);
+					}
+				} else {
+					writer->Write((uint16_t)0);
 				}
+
 				break;
 			}
 			case TextureAnimationParamsType::TextureCycle: {


### PR DESCRIPTION
The animated texture color params was treating all lists as if they had the same size, but there are valid assets in MM where the `envColorList` or `frameDataList` are `NULL`. ZAPD creates these vectors on the resource regardless if the addresses are null, and so the OTRExporter/resource importers were creating these arrays which would cause issues in MM.

Checking for `NULL` in the address and settings the size as 0 allows us to check that and set the values as `NULL` properly on the importer side.