### PR TITLE
Fix version file buffers not staying alive during o2r unload close

### DIFF
--- a/OTRExporter/Main.cpp
+++ b/OTRExporter/Main.cpp
@@ -120,7 +120,7 @@ static void ExporterProgramEnd()
     portVerWriter.Write(portVersion[1]); // Minor
     portVerWriter.Write(portVersion[2]); // Patch
     portVerWriter.Close();
-    
+
     if (Globals::Instance->fileMode == ZFileMode::ExtractDirectory)
     {
         std::string romPath = Globals::Instance->baseRomPath.string();
@@ -147,10 +147,12 @@ static void ExporterProgramEnd()
         otrArchive->CreateArchive(40000);
 
         printf("Adding game version file.\n");
-        otrArchive->AddFile("version", versionStream->ToVector().data(), versionStream->GetLength());
+        auto versionStreamBuffer = versionStream->ToVector();
+        otrArchive->AddFile("version", (void*)versionStreamBuffer.data(), versionStream->GetLength());
 
         printf("Adding portVersion file.\n");
-        otrArchive->AddFile("portVersion", portVersionStream->ToVector().data(), portVersionStream->GetLength());
+        auto portVersionStreamBuffer = portVersionStream->ToVector();
+        otrArchive->AddFile("portVersion", (void*)portVersionStreamBuffer.data(), portVersionStream->GetLength());
 
         for (const auto& item : files)
         {
@@ -166,9 +168,10 @@ static void ExporterProgramEnd()
             const auto& fileData = item.second;
             otrArchive->AddFile(fName, (void*)fileData.data(),	fileData.size());
         }
+
+        otrArchive = nullptr;
     }
 
-    otrArchive = nullptr;
     delete fileWriter;
     files.clear();
 


### PR DESCRIPTION
o2r archives using libzip requires that all buffers used with `AddFile` are maintained alive until the archive is unloaded. Otherwise the unload will write garbage data for those files.

the `version` and `portVersion` memory streams were returning temporary vector pointers or something, and the o2r was unloaded outside of the if block where the version stream is, so it was being destructed after the stream.

This addresses o2r archives showing as "unknown" game versions on the boot info.