### PR TITLE
Export additional data types on arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -344,6 +344,7 @@ baserom/
 baserom_ntsc/
 *.vtx.inc
 *.otr
+*.o2r
 *.swp
 *.a
 *.z64

--- a/OTRExporter/ArrayExporter.cpp
+++ b/OTRExporter/ArrayExporter.cpp
@@ -37,28 +37,32 @@ void OTRExporter_Array::Save(ZResource* res, const fs::path& outPath, BinaryWrit
 				// OTRTODO: Duplicate code here. Cleanup at a later date...
 				switch (vec->scalarType)
 				{
-				case ZScalarType::ZSCALAR_U8:
-					writer->Write(vec->scalars[k].scalarData.u8);
-					break;
 				case ZScalarType::ZSCALAR_S8:
 					writer->Write(vec->scalars[k].scalarData.s8);
 					break;
-				case ZScalarType::ZSCALAR_U16:
-					writer->Write(vec->scalars[k].scalarData.u16);
+				case ZScalarType::ZSCALAR_U8:
+				case ZScalarType::ZSCALAR_X8:
+					writer->Write(vec->scalars[k].scalarData.u8);
 					break;
 				case ZScalarType::ZSCALAR_S16:
 					writer->Write(vec->scalars[k].scalarData.s16);
+					break;
+				case ZScalarType::ZSCALAR_U16:
+				case ZScalarType::ZSCALAR_X16:
+					writer->Write(vec->scalars[k].scalarData.u16);
 					break;
 				case ZScalarType::ZSCALAR_S32:
 					writer->Write(vec->scalars[k].scalarData.s32);
 					break;
 				case ZScalarType::ZSCALAR_U32:
+				case ZScalarType::ZSCALAR_X32:
 					writer->Write(vec->scalars[k].scalarData.u32);
 					break;
 				case ZScalarType::ZSCALAR_S64:
 					writer->Write(vec->scalars[k].scalarData.s64);
 					break;
 				case ZScalarType::ZSCALAR_U64:
+				case ZScalarType::ZSCALAR_X64:
 					writer->Write(vec->scalars[k].scalarData.u64);
 					break;
 					// OTRTODO: ADD OTHER TYPES
@@ -75,28 +79,32 @@ void OTRExporter_Array::Save(ZResource* res, const fs::path& outPath, BinaryWrit
 
 			switch (scal->scalarType)
 			{
-			case ZScalarType::ZSCALAR_U8:
-				writer->Write(scal->scalarData.u8);
-				break;
 			case ZScalarType::ZSCALAR_S8:
 				writer->Write(scal->scalarData.s8);
 				break;
-			case ZScalarType::ZSCALAR_U16:
-				writer->Write(scal->scalarData.u16);
+			case ZScalarType::ZSCALAR_U8:
+			case ZScalarType::ZSCALAR_X8:
+				writer->Write(scal->scalarData.u8);
 				break;
 			case ZScalarType::ZSCALAR_S16:
 				writer->Write(scal->scalarData.s16);
+				break;
+			case ZScalarType::ZSCALAR_U16:
+			case ZScalarType::ZSCALAR_X16:
+				writer->Write(scal->scalarData.u16);
 				break;
 			case ZScalarType::ZSCALAR_S32:
 				writer->Write(scal->scalarData.s32);
 				break;
 			case ZScalarType::ZSCALAR_U32:
+			case ZScalarType::ZSCALAR_X32:
 				writer->Write(scal->scalarData.u32);
 				break;
 			case ZScalarType::ZSCALAR_S64:
 				writer->Write(scal->scalarData.s64);
 				break;
 			case ZScalarType::ZSCALAR_U64:
+			case ZScalarType::ZSCALAR_X64:
 				writer->Write(scal->scalarData.u64);
 				break;
 				// OTRTODO: ADD OTHER TYPES


### PR DESCRIPTION
The array exporter was not exporting scalar types marked as "hex" (e.g. `ZSCALAR_X8`)

These changes add all the `X` values into the export switches to export the unsigned value equivalent.