### PR TITLE
fix sample exporting

### DIFF
--- a/OTRExporter/AudioExporter.cpp
+++ b/OTRExporter/AudioExporter.cpp
@@ -69,13 +69,13 @@ std::string OTRExporter_Audio::GetSampleEntryReference(ZAudio* audio, SampleEntr
         {
             if (audio->sampleOffsets[entry->bankId][entry->sampleLoopOffset].find(entry->sampleDataOffset) != audio->sampleOffsets[entry->bankId][entry->sampleLoopOffset].end())
             {
-                return(StringHelper::Sprintf("audio/samples/%s", audio->sampleOffsets[entry->bankId][entry->sampleLoopOffset][entry->sampleDataOffset].c_str()));
+                return(StringHelper::Sprintf("audio/samples/%s_META", audio->sampleOffsets[entry->bankId][entry->sampleLoopOffset][entry->sampleDataOffset].c_str()));
             }
             else
-                return(entry->fileName);
+                return (entry->fileName + "_META");
         }
         else
-            return(entry->fileName);
+            return (entry->fileName + "_META");
     }
     else
         return("");
@@ -119,6 +119,7 @@ void OTRExporter_Audio::WriteSampleEntry(SampleEntry* entry, tinyxml2::XMLElemen
     
     sEntry->SetAttribute("LoopStart", entry->loop.start);
     sEntry->SetAttribute("LoopEnd", entry->loop.end);
+    sEntry->SetAttribute("LoopCount", entry->loop.count);
     
     for (size_t i = 0; i < entry->loop.states.size(); i++) {
         tinyxml2::XMLElement* loop = sEntry->InsertNewChildElement("LoopState");
@@ -129,7 +130,7 @@ void OTRExporter_Audio::WriteSampleEntry(SampleEntry* entry, tinyxml2::XMLElemen
     sEntry->SetAttribute("Order", entry->book.order);
     sEntry->SetAttribute("Npredictors", entry->book.npredictors);
 
-    for (size_t i = 0; i < entry->loop.states.size(); i++) {
+    for (size_t i = 0; i < entry->book.books.size(); i++) {
         tinyxml2::XMLElement* book = sEntry->InsertNewChildElement("Books");
         book->SetAttribute("Book", entry->book.books[i]);
         sEntry->InsertEndChild(book);
@@ -443,6 +444,7 @@ void OTRExporter_Audio::WriteSampleXML(ZAudio* audio) {
     for (const auto& pair : audio->samples) {
         tinyxml2::XMLDocument sample;
         tinyxml2::XMLElement* root = sample.NewElement("Sample");
+        root->SetAttribute("Version", 0);
 
         WriteSampleEntry(pair.second, root);
 

--- a/OTRExporter/AudioExporter.h
+++ b/OTRExporter/AudioExporter.h
@@ -20,14 +20,14 @@ private:
     void WriteSequenceXML(ZAudio* audio);
     void WriteSampleBinary(ZAudio* audio);
     void WriteSampleXML(ZAudio* audio);
-    std::string GetSampleEntryReference(ZAudio* audio, SampleEntry* entry, std::map<uint32_t, SampleEntry*> samples);
-    std::string GetSampleEntryStr(ZAudio* audio, const std::pair<const uint32_t, SampleEntry*>& pair);
-    std::string GetSampleDataStr(ZAudio* audio, const std::pair<const uint32_t, SampleEntry*>& pair);
+    std::string GetSampleEntryReference(ZAudio* audio, SampleEntry* entry, std::map<uint64_t, SampleEntry*> samples);
+    std::string GetSampleEntryStr(ZAudio* audio, const std::pair<const uint64_t, SampleEntry*>& pair);
+    std::string GetSampleDataStr(ZAudio* audio, const std::pair<const uint64_t, SampleEntry*>& pair);
     void WriteEnvData(std::vector<AdsrEnvelope*> envelopes, BinaryWriter* writer);
     void WriteEnvData(std::vector<AdsrEnvelope*> envelopes, tinyxml2::XMLElement* xmlDoc);
-    void WriteSoundFontEntry(ZAudio* audio, SoundFontEntry* entry, std::map<uint32_t, SampleEntry*> samples,
+    void WriteSoundFontEntry(ZAudio* audio, SoundFontEntry* entry, std::map<uint64_t, SampleEntry*> samples,
                              BinaryWriter* writer);
-    void WriteSoundFontEntry(ZAudio* audio, SoundFontEntry* entry, std::map<uint32_t, SampleEntry*> samples,
+    void WriteSoundFontEntry(ZAudio* audio, SoundFontEntry* entry, std::map<uint64_t, SampleEntry*> samples,
                              tinyxml2::XMLElement* xmlDoc, const char* name);
     const char* GetMediumStr(uint8_t medium);
     const char* GetCachePolicyStr(uint8_t policy);

--- a/OTRExporter/AudioExporter.h
+++ b/OTRExporter/AudioExporter.h
@@ -20,15 +20,13 @@ private:
     void WriteSequenceXML(ZAudio* audio);
     void WriteSampleBinary(ZAudio* audio);
     void WriteSampleXML(ZAudio* audio);
-    std::string GetSampleEntryReference(ZAudio* audio, SampleEntry* entry, std::map<uint64_t, SampleEntry*> samples);
-    std::string GetSampleEntryStr(ZAudio* audio, const std::pair<const uint64_t, SampleEntry*>& pair);
-    std::string GetSampleDataStr(ZAudio* audio, const std::pair<const uint64_t, SampleEntry*>& pair);
+    std::string GetSampleEntryReference(ZAudio* audio, SampleEntry* entry);
+    std::string GetSampleEntryStr(ZAudio* audio, SampleEntry* entry);
+    std::string GetSampleDataStr(ZAudio* audio, SampleEntry* entry);
     void WriteEnvData(std::vector<AdsrEnvelope*> envelopes, BinaryWriter* writer);
     void WriteEnvData(std::vector<AdsrEnvelope*> envelopes, tinyxml2::XMLElement* xmlDoc);
-    void WriteSoundFontEntry(ZAudio* audio, SoundFontEntry* entry, std::map<uint64_t, SampleEntry*> samples,
-                             BinaryWriter* writer);
-    void WriteSoundFontEntry(ZAudio* audio, SoundFontEntry* entry, std::map<uint64_t, SampleEntry*> samples,
-                             tinyxml2::XMLElement* xmlDoc, const char* name);
+    void WriteSoundFontEntry(ZAudio* audio, SoundFontEntry* entry, BinaryWriter* writer);
+    void WriteSoundFontEntry(ZAudio* audio, SoundFontEntry* entry, tinyxml2::XMLElement* xmlDoc, const char* name);
     const char* GetMediumStr(uint8_t medium);
     const char* GetCachePolicyStr(uint8_t policy);
     const char* GetCodecStr(uint8_t codec);

--- a/OTRExporter/AudioExporter.h
+++ b/OTRExporter/AudioExporter.h
@@ -4,11 +4,13 @@
 #include "ZAudio.h"
 #include "Exporter.h"
 #include <Utils/BinaryWriter.h>
+#include <tinyxml2.h>
 
 class OTRExporter_Audio : public OTRExporter
 {
 public:
     void WriteSampleEntry(SampleEntry* entry, BinaryWriter* writer);
+    void WriteSampleEntry(SampleEntry* entry, tinyxml2::XMLElement* writer);
     virtual void Save(ZResource* res, const fs::path& outPath, BinaryWriter* writer) override;
 
 private:
@@ -16,7 +18,11 @@ private:
     void WriteSoundFontTableXML(ZAudio* audio);
     void WriteSequenceBinary(ZAudio* audio);
     void WriteSequenceXML(ZAudio* audio);
+    void WriteSampleBinary(ZAudio* audio);
+    void WriteSampleXML(ZAudio* audio);
     std::string GetSampleEntryReference(ZAudio* audio, SampleEntry* entry, std::map<uint32_t, SampleEntry*> samples);
+    std::string GetSampleEntryStr(ZAudio* audio, const std::pair<const uint32_t, SampleEntry*>& pair);
+    std::string GetSampleDataStr(ZAudio* audio, const std::pair<const uint32_t, SampleEntry*>& pair);
     void WriteEnvData(std::vector<AdsrEnvelope*> envelopes, BinaryWriter* writer);
     void WriteEnvData(std::vector<AdsrEnvelope*> envelopes, tinyxml2::XMLElement* xmlDoc);
     void WriteSoundFontEntry(ZAudio* audio, SoundFontEntry* entry, std::map<uint32_t, SampleEntry*> samples,
@@ -25,5 +31,5 @@ private:
                              tinyxml2::XMLElement* xmlDoc, const char* name);
     const char* GetMediumStr(uint8_t medium);
     const char* GetCachePolicyStr(uint8_t policy);
-
+    const char* GetCodecStr(uint8_t codec);
 };


### PR DESCRIPTION
See https://github.com/louist103/ZAPDTR/pull/20 . Samples were not being exported correctly due to issues with loop offsets and names. This PR also changes how samples are named adding the bank ID to the file name.