### PR TITLE
Fix build on GCC 14

### DIFF
--- a/OTRExporter/ExporterArchiveOTR.cpp
+++ b/OTRExporter/ExporterArchiveOTR.cpp
@@ -25,7 +25,7 @@ bool ExporterArchiveOtr::Load(bool enableWriting) {
     }
     if (openArchiveSuccess) {
         printf("Opened mpq file ");
-        printf(fullPath.c_str());
+        printf("%s", fullPath.c_str());
         printf("\n");
         mMpq = mpqHandle;
         mPath = fullPath;       


### PR DESCRIPTION
Was trying to build 2ship on GCC 14 but was getting the following error, this PR fixes it.

```
.../2ship2harkinian/OTRExporter/OTRExporter/ExporterArchiveOTR.cpp: In member function ‘virtual bool ExporterArchiveOtr::Load(bool)’:
.../2ship2harkinian/OTRExporter/OTRExporter/ExporterArchiveOTR.cpp:28:15: error: format not a string literal and no format arguments [-Werror=format-security]
   28 |         printf(fullPath.c_str());
      |         ~~~~~~^~~~~~~~~~~~~~~~~~
cc1plus: some warnings being treated as errors
ninja: build stopped: subcommand failed.
```